### PR TITLE
wazero: updates with better close function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/birros/wazero-demo
 go 1.17
 
 require (
-	github.com/tetratelabs/wazero v0.0.0-20220324233430-a1dc1f56a04c
+	github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f
 	golang.org/x/mobile v0.0.0-20220307220422-55113b94f09c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220324233430-a1dc1f56a04c h1:jSJwPbAH+hSbMw5SBrq7uT/5GCubSku0L4UX7o0o6II=
-github.com/tetratelabs/wazero v0.0.0-20220324233430-a1dc1f56a04c/go.mod h1:jF+njZWLD70K/xB02hWVz5aQ2m+RCfFjIUJi44t9zOo=
+github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f h1:xrrGZ18UDpAzLwUCakRJDeT/qgywEdVaupODVtRB00U=
+github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f/go.mod h1:jF+njZWLD70K/xB02hWVz5aQ2m+RCfFjIUJi44t9zOo=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
Most recent code exits the module with a `sys.ExitError`, if something
compiled WASI in a way that invokes "proc_exit". While your code isn't
doing that, it is helpful to have the update in case a future change
does :D