### PR TITLE
Updates to wazero with built-in assembler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/birros/wazero-demo
 go 1.17
 
 require (
-	github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f
+	github.com/tetratelabs/wazero v0.0.0-20220331063638-a351daa8586c
 	golang.org/x/mobile v0.0.0-20220307220422-55113b94f09c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f h1:xrrGZ18UDpAzLwUCakRJDeT/qgywEdVaupODVtRB00U=
-github.com/tetratelabs/wazero v0.0.0-20220330094601-81c2414fff9f/go.mod h1:jF+njZWLD70K/xB02hWVz5aQ2m+RCfFjIUJi44t9zOo=
+github.com/tetratelabs/wazero v0.0.0-20220331063638-a351daa8586c h1:/1H9f+BnwsqNc89se4aZMvrmoea7SKs/Wyjp2NAVlhc=
+github.com/tetratelabs/wazero v0.0.0-20220331063638-a351daa8586c/go.mod h1:jF+njZWLD70K/xB02hWVz5aQ2m+RCfFjIUJi44t9zOo=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
This reduces the size of the exe from 5MB to 3MB. This is amazing as the
baseline size of a go binary is >1.5MB. @mathetake is to thank for being
so daring!