### PR TITLE
Updates to wazero which uses context everywhere

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/birros/wazero-demo
 go 1.17
 
 require (
-	github.com/tetratelabs/wazero v0.0.0-20220415013152-106f96b066b4
+	github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a
 	golang.org/x/mobile v0.0.0-20220307220422-55113b94f09c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/tetratelabs/wazero v0.0.0-20220415013152-106f96b066b4 h1:fOrmLdk7JVRWv8JA5NcI6kRNIX2AhTvNK8crZojPZj4=
-github.com/tetratelabs/wazero v0.0.0-20220415013152-106f96b066b4/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a h1:k9hVyZcNAVhiVp8YE6r2Trji8HD8CHleaQhqHZDXaEM=
+github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -15,34 +15,32 @@ var sumWASMBytes []byte
 func Start() {
 	log.SetFlags(log.Lshortfile)
 
+	// Assign a Go context used during instantiation and any function calls.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Assign the Go context to the runtime, so it is used during instantiation
-	// and any function calls.
-	runtime := wazero.NewRuntimeWithConfig(
-		wazero.NewRuntimeConfig().WithContext(ctx),
-	)
+	// Create a new WebAssembly Runtime.
+	runtime := wazero.NewRuntime()
 
 	// sum.wasm was compiled with TinyGo, which requires being instantiated as a
 	// WASI command (to initialize memory).
 	// This is required by TinyGo even if the source (../sum/sum.go in this
 	// case) doesn't directly use I/O or memory.
-	wm, err := wasi.InstantiateSnapshotPreview1(runtime)
+	wm, err := wasi.InstantiateSnapshotPreview1(ctx, runtime)
 	if err != nil {
 		log.Panicln(err)
 	}
-	defer wm.Close()
+	defer wm.Close(ctx)
 
-	module, err := runtime.InstantiateModuleFromCode(sumWASMBytes)
+	module, err := runtime.InstantiateModuleFromCode(ctx, sumWASMBytes)
 	if err != nil {
 		log.Panicln(err)
 	}
-	defer module.Close()
+	defer module.Close(ctx)
 
 	sum := module.ExportedFunction("sum")
 
-	result, err := sum.Call(nil, 30, 12)
+	result, err := sum.Call(ctx, 30, 12)
 	if err != nil {
 		log.Panicln(err)
 	}


### PR DESCRIPTION
While we don't have interceptors (like tracing) yet, this is the motivation of having context for all the lifecycle phases. Ex, so you can know which function called module.Close, etc.