### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.18.1
-tinygo 0.23.0
-binaryen 105
+golang 1.18.5
+tinygo 0.25.0
+binaryen 109

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/birros/wazero-demo
 
-go 1.17
+go 1.18
 
 require (
-	github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142
+	github.com/tetratelabs/wazero v1.0.0-beta.1
 	golang.org/x/mobile v0.0.0-20220307220422-55113b94f09c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142 h1:ZnK50yYXmYRlAOpOzYw6Xu/QWU2kP8bDeVLQDzQtTas=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -20,7 +20,9 @@ func Start() {
 	defer cancel()
 
 	// Create a new WebAssembly Runtime.
-	runtime := wazero.NewRuntime()
+	runtime := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
+		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
+		WithWasmCore2())
 	defer runtime.Close(ctx) // This closes everything this Runtime created.
 
 	// sum.wasm was compiled with TinyGo, which requires being instantiated as a

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -20,9 +20,11 @@ func Start() {
 	defer cancel()
 
 	// Create a new WebAssembly Runtime.
-	runtime := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
+	runtime := wazero.NewRuntimeWithConfig(
+		ctx,
 		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+		wazero.NewRuntimeConfig().WithWasmCore2(),
+	)
 	defer runtime.Close(ctx) // This closes everything this Runtime created.
 
 	// sum.wasm was compiled with TinyGo, which requires being instantiated as a


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io), 1.0.0-beta.1.

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.